### PR TITLE
Bugs in merging function?

### DIFF
--- a/src/dartsort/clustering/agglomerate.py
+++ b/src/dartsort/clustering/agglomerate.py
@@ -733,7 +733,7 @@ def _combine_loop(
                 continue
 
             eq_ncandj = rcand[j + 1 :] == ncandj
-            if eq_ncandj.sum() <= 1:
+            if eq_ncandj.sum() < 1:
                 continue
 
             rsum = mergedr[s, j]

--- a/src/dartsort/clustering/agglomerate.py
+++ b/src/dartsort/clustering/agglomerate.py
@@ -698,7 +698,7 @@ def combine_gmm_scores(
 
     # check invariants at the bottom
     if mergedr.shape[1] > 2:
-        assert np.all(np.diff(mergedr[:, : cand.shape[1]], axis=1) <= 0)
+        assert np.all(np.diff(mergedl[:, : cand.shape[1]], axis=1) <= 0)    ## this should be ensuring mergedl is ascending ? 
     assert np.greater_equal(np.isneginf(mergedl[:, : cand.shape[1]]), cand == -1).all()
     assert (cand < 0).sum() >= nbye
     if sorting.labels is not None:


### PR DESCRIPTION
Hey Charlie,
Excited to give this a spin! Two small questions below: 

1) the assertion is checking that mergedr is descending, but earlier you sort on mergedl? This gets thrown when i sort a longer recording (~2.5hrs) but not on a short 10 min one.

2) in the boolean mask used to check for duplicate unit IDs, if theres exactly one duplicate then eq_ncandj.sum() = 1 so you should combine the scores?

Let me know if this is the expected behavior should be! 